### PR TITLE
Fix manifest merge issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ repositories {
 }
 
 dependencies {
-    compile('com.github.jkwiecien:CountingTextView:1.0.10') {
-        exclude module: 'appcompat-v7'
-    }
+    compile 'com.github.jkwiecien:CountingTextView:1.0.10'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,6 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+ANDROID_BUILD_SDK_VERSION=23
+ANDROID_BUILD_TOOLS_VERSION=23.0.2

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'android-maven'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.0"
+    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 11
@@ -20,6 +20,4 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.1.1'
 }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,8 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.aprilapps.countingtextview">
-
-    <application android:allowBackup="true" android:label="@string/app_name">
-
-    </application>
-
-</manifest>
+<manifest package="com.aprilapps.countingtextview"/>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">CountingTextView</string>
-</resources>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.0"
+    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
+    buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
         applicationId "com.aprilapps.countingtextviewsample"
@@ -20,6 +20,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile(project(':library'))
+    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile project(':library')
 }

--- a/sample/src/main/java/com/aprilapps/countingtextviewsample/MainActivity.java
+++ b/sample/src/main/java/com/aprilapps/countingtextviewsample/MainActivity.java
@@ -1,14 +1,16 @@
 package com.aprilapps.countingtextviewsample;
 
-import android.app.Activity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
+
+import com.aprilapps.countingtextview.CountingTextView;
 
 import java.util.Random;
 
 
-public class MainActivity extends Activity {
+public class MainActivity extends AppCompatActivity {
 
     private Random random = new Random();
 


### PR DESCRIPTION
- Fix manifest merge issue

`Error:Execution failed for task ':ScoreIt:processDebugManifest'.
 Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:26:9-36
    is also present at [com.github.jkwiecien:CountingTextView:1.0.10] AndroidManifest.xml:12:9-35 value=(true).
    Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:25:5-66:19 to override.'`
- Update build tools.
